### PR TITLE
Show dates on home and timeline

### DIFF
--- a/frontend/app/(home)/_homepageContent.tsx
+++ b/frontend/app/(home)/_homepageContent.tsx
@@ -107,9 +107,17 @@ export default function HomepageContent() {
           <Box>
             <Text>
               Hey there! We&apos;re incredibly excited to get everyone together
-              for a big knees-up. Right now, we&apos;ve got some high-level
-              details up and running, but stay tuned as we&apos;ll be updating
-              with more juicy info as the big day approaches.
+              for a big knees-up on the{" "}
+              {weddingDateEnv
+                ? weddingDateEnv.toLocaleDateString("en-GB", {
+                    day: "numeric",
+                    month: "long",
+                    year: "numeric",
+                  })
+                : "TBD"}
+              . Right now, we&apos;ve got some high-level details up and
+              running, but stay tuned as we&apos;ll be updating with more juicy
+              info as the big day approaches.
             </Text>
 
             <Text>

--- a/frontend/app/timeline/_timelineContent.tsx
+++ b/frontend/app/timeline/_timelineContent.tsx
@@ -18,6 +18,18 @@ import GetReadyHut from "@/public/images/get-ready-hut.png";
 import BreakfastShack from "@/public/images/breakfast-shack.png";
 
 export default function TimelineContent() {
+  const weddingDateEnv = process.env.NEXT_PUBLIC_WEDDING_DATETIME
+    ? new Date(process.env.NEXT_PUBLIC_WEDDING_DATETIME)
+    : undefined;
+
+  const weddingDateBefore = weddingDateEnv
+    ? new Date(weddingDateEnv.getTime() - 24 * 60 * 60 * 1000)
+    : undefined;
+
+  const weddingDateAfter = weddingDateEnv
+    ? new Date(weddingDateEnv.getTime() + 24 * 60 * 60 * 1000)
+    : undefined;
+
   return (
     <>
       <Text>
@@ -42,7 +54,12 @@ export default function TimelineContent() {
       <Grid style={{ padding: "0 30px" }}>
         <Grid.Col span={{ base: 12, md: 4 }}>
           <Title order={2} style={{ padding: "10px 0" }}>
-            Day 1
+            {weddingDateBefore
+              ? weddingDateBefore.toLocaleDateString("en-GB", {
+                  day: "numeric",
+                  month: "long",
+                })
+              : "TBD"}
           </Title>
           <Space h="md" />
 
@@ -90,7 +107,12 @@ export default function TimelineContent() {
 
         <Grid.Col span={{ base: 12, md: 4 }}>
           <Title order={2} style={{ padding: "10px 0" }}>
-            Day 2
+            {weddingDateEnv
+              ? weddingDateEnv.toLocaleDateString("en-GB", {
+                  day: "numeric",
+                  month: "long",
+                })
+              : "TBD"}
           </Title>
           <Space h="md" />
 
@@ -161,7 +183,12 @@ export default function TimelineContent() {
 
         <Grid.Col span={{ base: 12, md: 4 }}>
           <Title order={2} style={{ padding: "10px 0" }}>
-            Day 3
+            {weddingDateAfter
+              ? weddingDateAfter.toLocaleDateString("en-GB", {
+                  day: "numeric",
+                  month: "long",
+                })
+              : "TBD"}
           </Title>
           <Space h="md" />
 


### PR DESCRIPTION
## Overview of changes

Made the text on the homepage, and the days on the timeline pull in the actual date, e.g. (fake date for local dev)

Homepage
![image](https://github.com/user-attachments/assets/a9fb50ea-ffc6-4d44-9cff-f583513f355b)

Timeline
![image](https://github.com/user-attachments/assets/c75bdf27-a925-47ce-a1d3-3f8361ef568d)

## Checklist

- [x] I have tested these changes locally using the automated tests

## Reviewer instructions

Nothing beyond checking you're happy with the screenshots above