### PR TITLE
deps: bump picomatch to 4.0.4 via resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@typescript-eslint/scope-manager": "8.57.2",
     "@typescript-eslint/visitor-keys": "8.57.2",
     "@typescript-eslint/project-service": "8.57.2",
-    "@typescript-eslint/tsconfig-utils": "8.57.2"
+    "@typescript-eslint/tsconfig-utils": "8.57.2",
+    "picomatch": "^4.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7468,17 +7468,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.3.1":
-  version: 2.3.2
-  resolution: "picomatch@npm:2.3.2"
-  checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61
-  languageName: node
-  linkType: hard
-
-"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "picomatch@npm:4.0.3"
-  checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
+"picomatch@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Adds `picomatch` to the `resolutions` field in `package.json`, pinning it to `^4.0.4`
- This forces yarn to resolve all transitive uses of picomatch to `4.0.4`, replacing the vulnerable `4.0.3` that was being pulled in by multiple dependencies

## Motivation

`picomatch@4.0.3` contains a security vulnerability. The affected transitive dependency chains were:

- `@jest/globals` → picomatch 4.0.3
- `@types/jest` → picomatch 4.0.3
- `babel-jest` → picomatch 4.0.3
- `eslint-config-next` → picomatch 4.0.3
- `jest` → picomatch 4.0.3
- `jest-environment-jsdom` → picomatch 4.0.3
- `postcss-preset-mantine` → picomatch 4.0.3

Rather than waiting for all upstream packages to bump their own pinned versions, a yarn `resolutions` override ensures the patched version is used immediately across the entire dependency tree.

## Testing

`yarn test` passes (prettier, eslint, jest, next build, playwright — 12 tests passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)